### PR TITLE
Add Russian T9 for Dialer (author @dimfishr) [1\2]

### DIFF
--- a/res/values-ru/strings.xml
+++ b/res/values-ru/strings.xml
@@ -17,6 +17,24 @@
 
 <resources xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+
+    <!--  Do not translate. -->
+    <string name="dialpad_2_letters">АБВГ</string>
+    <!--  Do not translate. -->
+    <string name="dialpad_3_letters">ДЕЖЗ</string>
+    <!--  Do not translate. -->
+    <string name="dialpad_4_letters">ИЙКЛ</string>
+    <!--  Do not translate. -->
+    <string name="dialpad_5_letters">МНОП</string>
+    <!--  Do not translate. -->
+    <string name="dialpad_6_letters">РСТУ</string>
+    <!--  Do not translate. -->
+    <string name="dialpad_7_letters">ФХЦЧ</string>
+    <!--  Do not translate. -->
+    <string name="dialpad_8_letters">ШЩЪЫ</string>
+    <!--  Do not translate. -->
+    <string name="dialpad_9_letters">ЬЭЮЯ</string>
+
     <string name="description_dialpad_back" msgid="8370856774250260053">"Вернуться"</string>
     <string name="description_dialpad_overflow" msgid="4853244877599437286">"Ещё"</string>
     <string name="description_delete_button" msgid="88733669653753441">"Клавиша Backspace."</string>


### PR DESCRIPTION
PS6:  final nitpick: replaced getLanguage() with
      getCountry() call - primarily for those who are
      going to implement Chinese Traditional/Simplified
      support (because they all have "zh" language code,
      but letters are different in rHK/rCN)
PS7:  polishing: wrapped some lines at 100 chars, restored
      original dimens.xml / colors.xml values (looks better
      with 41dp, color change could go into another commit)
      ... purged earlier patch set changes
PS8:  fixed MDPI compatibility, marked 1/0/*/# "letters" as
      untranslatable (they are not displayed in any case)
PS9 & PS10: added "values-en-rRU" (Dmitriy).
PS11: minor padding tweak (7dp -> 8 dp).
PS12: fix buttons being 11dp off to the left, this can not
      be unseen.

Conflicts:
	src/com/android/dialer/DialtactsActivity.java

Change-Id: I5b6c8e399b98b8b95aab0ddd02d50d1c69db50ba